### PR TITLE
Fix gosec installation repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         go-version: '1.23'
     
     - name: Install Gosec
-      run: go install github.com/securecodewarrior/gosec/v2/cmd/gosec@latest
+      run: go install github.com/securego/gosec/v2/cmd/gosec@latest
     
     - name: Run Gosec Security Scanner
       run: gosec ./...


### PR DESCRIPTION
## Problem

The Security Scan step was failing with:

```
go: github.com/securecodewarrior/gosec/v2/cmd/gosec@latest: module github.com/securecodewarrior/gosec/v2/cmd/gosec: git ls-remote -q origin in /home/runner/go/pkg/mod/cache/vcs/...: exit status 128:
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

## Root Cause

The gosec project was moved from `github.com/securecodewarrior/gosec` to `github.com/securego/gosec` and the old repository is no longer accessible.

## Solution

✅ Updated the installation command to use the correct repository: `github.com/securego/gosec`

## Result

The Security Scan step should now work properly in CI without authentication errors.