### PR TITLE
Add release badge back to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Go Version](https://img.shields.io/github/go-mod/go-version/nhalm/dbutil)](https://golang.org/doc/devel/release.html)
 [![CI Status](https://github.com/nhalm/dbutil/actions/workflows/ci.yml/badge.svg)](https://github.com/nhalm/dbutil/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/nhalm/dbutil)](https://goreportcard.com/report/github.com/nhalm/dbutil)
+[![Release](https://img.shields.io/github/v/release/nhalm/dbutil)](https://github.com/nhalm/dbutil/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A reusable Go package that provides database connection utilities and testing infrastructure for applications using PostgreSQL with pgx and sqlc.


### PR DESCRIPTION
## Why Add It Back?\n\nNow that the release workflow is properly configured and working:\n\n✅ **Release workflow triggers** on git tags  \n✅ **Automated releases** with changelogs  \n✅ **v0.2.1 tag** was just created successfully  \n✅ **Badge will show current version** and link to releases page  \n\n## Badge Benefits:\n\n- **Shows latest version** (v0.2.1) for quick reference\n- **Links to releases page** where users can see changelogs  \n- **Indicates active maintenance** of the project\n- **Helps users choose version** for `go get` commands\n\n## Result:\n\nUsers can quickly see the current version and access release notes! 🚀